### PR TITLE
Use regexp.MustCompile at initialize 

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -5,16 +5,19 @@ import (
 	"strings"
 )
 
+var (
+	crawlerReg   = regexp.MustCompile(CombineRegexp(CrawlersList()))
+	exclusionReg = regexp.MustCompile(CombineRegexp(ExclusionsList()))
+)
+
 // CrawlerDetector is crawler detector structure
 type CrawlerDetector struct {
-	Crawlers   []string
-	Exclusions []string
-	Matched    []string
+	Matched []string
 }
 
 // New returns a new initialized CrawlerDetector
 func New() *CrawlerDetector {
-	return &CrawlerDetector{CrawlersList(), ExclusionsList(), []string{}}
+	return &CrawlerDetector{Matched: []string{}}
 }
 
 // IsCrawler is detect crawlers/spiders/bots by user agent
@@ -23,8 +26,7 @@ func (cd *CrawlerDetector) IsCrawler(userAgent string) bool {
 		return false
 	}
 
-	cReg := regexp.MustCompile(cd.CombineRegexp(cd.Crawlers))
-	cd.Matched = cReg.FindAllString(userAgent, -1)
+	cd.Matched = crawlerReg.FindAllString(userAgent, -1)
 
 	if len(cd.Matched) != 0 {
 		return true
@@ -35,8 +37,7 @@ func (cd *CrawlerDetector) IsCrawler(userAgent string) bool {
 
 // IsExclusion is detect exclusion from user agent
 func (cd *CrawlerDetector) IsExclusion(userAgent string) bool {
-	eReg := regexp.MustCompile(cd.CombineRegexp(cd.Exclusions))
-	isExclusion := eReg.ReplaceAllString(userAgent, "")
+	isExclusion := exclusionReg.ReplaceAllString(userAgent, "")
 
 	if len(isExclusion) == 0 {
 		return true
@@ -46,19 +47,19 @@ func (cd *CrawlerDetector) IsExclusion(userAgent string) bool {
 }
 
 // CombineRegexp is build regex from givement patterns list
-func (cd *CrawlerDetector) CombineRegexp(patterns []string) string {
+func CombineRegexp(patterns []string) string {
 	return "(" + strings.Join(patterns, "|") + ")"
 }
 
 // SetCrawlers is setter for custom crawlers list
 func (cd *CrawlerDetector) SetCrawlers(list []string) *CrawlerDetector {
-	cd.Crawlers = list
+	crawlerReg = regexp.MustCompile(CombineRegexp(list))
 	return cd
 }
 
 // SetExclusions is setter for custom exclusions list
 func (cd *CrawlerDetector) SetExclusions(list []string) *CrawlerDetector {
-	cd.Exclusions = list
+	exclusionReg = regexp.MustCompile(CombineRegexp(list))
 	return cd
 }
 


### PR DESCRIPTION
# What 
Use regexp.MustCompile at initialize.

# Why
Memory allocation increases if call egexp.MustCompile every time.

# Benchmark

### Before
```
% go test -bench . -benchmem -count 10
goos: darwin
goarch: amd64
Benchmark-4   	     285	   4075415 ns/op	 3897139 B/op	   10689 allocs/op
Benchmark-4   	     285	   3920721 ns/op	 3895709 B/op	   10689 allocs/op
Benchmark-4   	     306	   4015023 ns/op	 3892322 B/op	   10688 allocs/op
Benchmark-4   	     312	   4010971 ns/op	 3844592 B/op	   10673 allocs/op
Benchmark-4   	     295	   3952617 ns/op	 3877776 B/op	   10683 allocs/op
Benchmark-4   	     300	   3966906 ns/op	 3935338 B/op	   10701 allocs/op
Benchmark-4   	     303	   4065627 ns/op	 3875472 B/op	   10683 allocs/op
Benchmark-4   	     288	   4009928 ns/op	 3911417 B/op	   10694 allocs/op
Benchmark-4   	     280	   4001413 ns/op	 3875501 B/op	   10683 allocs/op
Benchmark-4   	     291	   4039852 ns/op	 3874006 B/op	   10682 allocs/op
PASS
ok  	17.772s
```

### After
```
% go test -bench . -benchmem -count 10
goos: darwin
goarch: amd64
Benchmark-4   	   29426	     40330 ns/op	      72 B/op	       3 allocs/op
Benchmark-4   	   30420	     40890 ns/op	      71 B/op	       3 allocs/op
Benchmark-4   	   30778	     39153 ns/op	      70 B/op	       3 allocs/op
Benchmark-4   	   30156	     40019 ns/op	      74 B/op	       3 allocs/op
Benchmark-4   	   30076	     43263 ns/op	      71 B/op	       3 allocs/op
Benchmark-4   	   17292	    116810 ns/op	      89 B/op	       3 allocs/op
Benchmark-4   	   23704	     46410 ns/op	      48 B/op	       3 allocs/op
Benchmark-4   	   26802	     44341 ns/op	      74 B/op	       3 allocs/op
Benchmark-4   	   24050	     44967 ns/op	      48 B/op	       3 allocs/op
Benchmark-4   	   23432	     45049 ns/op	      78 B/op	       3 allocs/op
PASS
ok  	18.609s
```